### PR TITLE
COMPASS-3963: Updated color palette 2019

### DIFF
--- a/src/assets/less/compass/message-background.less
+++ b/src/assets/less/compass/message-background.less
@@ -31,7 +31,7 @@ ul.message-background li {
   margin: 0;
   padding: 0;
   list-style: none;
-  color: @gray5;
+  color: @grayLight1;
 }
 
 .message-background-tip {

--- a/src/assets/less/compass/palette.less
+++ b/src/assets/less/compass/palette.less
@@ -1,6 +1,41 @@
 @sidebar-bg: @slate1;
 @sidebar-width: 250px;
 
+/* MongoDB Color Palette 2019 */
+@black: #061621;
+@grayDark3: #21313C;
+@grayDark2: #3D4F58;
+@grayDark1: #5D6C74;
+@grayBase: #9FA1A2;
+@grayLight1: #B8C4C2;
+@grayLight2: #E7EEEC;
+@grayLight3: #F9FBFA;
+@white: #ffffff;
+
+@greenDark3: #0E6834;
+@greenDark2: #116149;
+@greenBase: #13AA52;
+@greenLight2: #C3E7CA;
+@greenLight3: #E4F4E4;
+
+@blueDark3: #0D324F;
+@blueDark2: #1A567E;
+@blueBase: #007CAD;
+@blueLight2: #C5E4F2;
+@blueLight3: #E1F2F6;
+
+@yellowDark3: #543E07;
+@yellowDark2: #86681D;
+@yellowBase: #FFDD49;
+@yellowLight2: #FEF2C8;
+@yellowLight3: #FEF7E3;
+
+@redDark3: #570B08;
+@redDark2: #8F221B;
+@redBase: #CF4A22;
+@redLight2: #F9D3C5;
+@redLight3: #FCEBE2;
+
 /* MongoDB Color Palette */
 /* commented colors have been deprecated */
 @green0: #0E7E3D; 

--- a/src/components/status.less
+++ b/src/components/status.less
@@ -33,7 +33,7 @@
   }
 
   &-bar {
-    background-color: @green2;
+    background-color: @greenBase;
     height: 4px;
     transition: width .6s ease;
 
@@ -79,7 +79,7 @@
 
   &-text {
     visiblity: hidden;
-    color: #bfbfbe;
+    color: @grayLight1;
     font-size: 28px;
     font-weight: 400;
     width: 100%;


### PR DESCRIPTION
Updated color palette to: https://mongodb.github.io/leafygreen-ui/?path=/story/palette--ui

<img width="573" alt="Screen Shot 2019-11-18 at 9 52 45 AM" src="https://user-images.githubusercontent.com/7270285/69062619-320d8c00-09e9-11ea-93c8-80f5a24dfd15.png">
